### PR TITLE
issue #25 add newsletter checkbox

### DIFF
--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1819,7 +1819,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 * @return bool
 	 */
 	function show_additional_checkbox() {
-		$show = true;
+		$show = false;
 
 		return apply_filters( 'kco_show_additional_checkbox', $show );
 	}

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1813,6 +1813,65 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		return $actions;
 	}
 
+	/**
+	 * Determine whether to show additional checkbox
+	 *
+	 * @return bool
+	 */
+	function show_additional_checkbox() {
+		$show = true;
+
+		return apply_filters( 'kco_show_additional_checkbox', $show );
+	}
+
+
+	/**
+	 * Get the text for the additional text box
+	 *
+	 * @return string
+	 */
+	function additional_checkbox_text() {
+
+		$checkbox_text = __( 'Subscribe to newsletter', 'woocommerce-gateway-klarna' );
+
+		return apply_filters( 'kco_additional_checkbox_text', $checkbox_text );
+	}
+
+
+	/**
+	 * Determine whether additional checkbox is checked by default
+	 *
+	 * @return bool
+	 */
+	function additional_checkbox_checked() {
+		$checked = true;
+
+		return apply_filters( 'kco_additional_checkbox_checked', $checked );
+	}
+
+
+	/**
+	 * Determine whether the additional checkbox is required
+	 *
+	 * @return bool
+	 */
+	function additional_checkbox_required() {
+		$required = false;
+
+		return apply_filters( 'kco_additional_checkbox_required', $required );
+	}
+
+	/**
+	 * Add postmeta for the additional checkbox
+	 * 
+	 * @param int   $order_id
+     * @param bool  $checkbox_value
+	 */
+	function set_additional_checkbox_value( $order_id, $checkbox_value ) {
+		$meta_value = ( $checkbox_value ) ? '1' : '0';
+	    update_post_meta( $order_id, '_kco_additional_checkbox',  $meta_value );
+	}
+
 } // End class WC_Gateway_Klarna_Checkout
 // Extra Class for Klarna Checkout
 class WC_Gateway_Klarna_Checkout_Extra {

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -166,11 +166,13 @@ if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 	update_post_meta( $local_order_id, '_billing_country', WC()->session->get( 'klarna_country' ), true );
 
 	// Set the value for the additional checkbox
-	if ( 'yes' == $this->debug ) {
-		$debug_value = ( $klarna_order['merchant_requested']['additional_checkbox'] ) ? 'true' : 'false';
-		$this->log->add('klarna', "[checkout.php] Setting value of additional checkbox to " . $debug_value . '...');
-	}
-	$this->set_additional_checkbox_value( $local_order_id, $klarna_order['merchant_requested']['additional_checkbox'] );
+    if ( $this->show_additional_checkbox() ) {
+        if ('yes' == $this->debug) {
+            $debug_value = ($klarna_order['merchant_requested']['additional_checkbox']) ? 'true' : 'false';
+            $this->log->add('klarna', "[checkout.php] Setting value of additional checkbox to " . $debug_value . '...');
+        }
+        $this->set_additional_checkbox_value($local_order_id, $klarna_order['merchant_requested']['additional_checkbox']);
+    }
 
 	// Set session values for Klarna order ID and Klarna order country
 	WC()->session->set( 'klarna_checkout', $sessionId );

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -165,6 +165,13 @@ if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 	update_post_meta( $local_order_id, '_klarna_order_id', $klarna_order['order_id'], true );
 	update_post_meta( $local_order_id, '_billing_country', WC()->session->get( 'klarna_country' ), true );
 
+	// Set the value for the additional checkbox
+	if ( 'yes' == $this->debug ) {
+		$debug_value = ( $klarna_order['merchant_requested']['additional_checkbox'] ) ? 'true' : 'false';
+		$this->log->add('klarna', "[checkout.php] Setting value of additional checkbox to " . $debug_value . '...');
+	}
+	$this->set_additional_checkbox_value( $local_order_id, $klarna_order['merchant_requested']['additional_checkbox'] );
+
 	// Set session values for Klarna order ID and Klarna order country
 	WC()->session->set( 'klarna_checkout', $sessionId );
 	WC()->session->set( 'klarna_checkout_country', WC()->customer->get_country() );

--- a/includes/checkout/create.php
+++ b/includes/checkout/create.php
@@ -250,6 +250,13 @@ if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_cont
 	}
 }
 
+// Show additional checkbox if needed.
+if ( $this->show_additional_checkbox() ) {
+	$create['options']['additional_checkbox']['text'] = $this->additional_checkbox_text();
+	$create['options']['additional_checkbox']['checked'] = $this->additional_checkbox_checked();
+	$create['options']['additional_checkbox']['required'] = $this->additional_checkbox_required();
+}
+
 if ( $this->is_rest() ) {
 	$create['order_amount']     = (int) $klarna_order_total;
 	$create['order_tax_amount'] = (int) $klarna_tax_total;

--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -72,6 +72,15 @@ if ( $klarna_order['status'] == 'checkout_incomplete' ) {
 	exit;
 }
 
+// Check and save value of additional checkbox if applicable
+if ( $this->show_additional_checkbox() ) {
+    if ( $this->debug == 'yes' ) {
+        $debug_value = ( $klarna_order['merchant_requested']['additional_checkbox'] ) ? 'true' : 'false';
+        $this->log->add('klarna', "[thank-you.php] Setting value of additional checkbox to " . $debug_value . '...');
+    }
+    $this->set_additional_checkbox_value(WC()->session->get('ongoing_klarna_order'), $klarna_order['merchant_requested']['additional_checkbox'] );
+}
+
 // Display Klarna iframe
 if ( $this->is_rest() ) {
 	$snippet = '<div>' . $klarna_order['html_snippet'] . '</div>';


### PR DESCRIPTION
Issue #25  

Initial solution - add checkbox parameter to initial request to Klarna, store checkbox value in local order, update checkbox value when receiving confirmation on the thank-you page.

The checkbox currently doesn't work during AJAX. This means:

- On order/checkout creation, the checkbox is in the default state
- Check/uncheck the checkbox (change from default)
- Update the cart by changing shipping or quantity of item
- On AJAX refresh of iFrame, checkbox is now back to default state

Klarna does not seem to trigger any javascript event for when the checkbox changes state. An alternative solution might be

1. Use own javascript to detect checkbox change
2. Record that and send value to server side
3. Send updated checkbox value as new "default" in resume.php. Something like
       `$update['options']['additional_checkbox']['checked'] = new_javacsripe_value;`

I did not yet find the best way to do that. I am not familiar enough with your plugin and Klarna's API. I wanted to make a pull request and discuss before wasting a lot of time on it.