### PR TITLE
WC 3.0 compatibility: Save payment method

### DIFF
--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -772,6 +772,8 @@ class WC_Gateway_Klarna_K2WC {
 		$payment_method     = $available_gateways['klarna_checkout'];
 
 		$order->set_payment_method( $payment_method );
+		
+		$order->save();
 	}
 
 	/**


### PR DESCRIPTION
In 3.0.0, using $order->set_payment_method() also requires a call to $order->save() to persist the data.

See https://github.com/woocommerce/woocommerce/wiki/2.6.x-to-3.0.0-Developer-Migration-Notes#set_payment_method-does-not-update-meta-values