### PR TITLE
Remove the need to have td named .product-quantity

### DIFF
--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -353,7 +353,7 @@ jQuery(document).ready(function ($) {
 				});
 			}
 
-			ancestor = $(this).closest('tr').find('td.product-quantity');
+			ancestor = $(this).closest('tr').find('.product-quantity');
 			item_row = $(this).closest('tr');
 			kco_widget = $('#klarna-checkout-widget');
 			cart_item_key_remove = $(ancestor).data('cart_item_key');


### PR DESCRIPTION
This makes it possible to change the html markup if we want to overwrite the kco cart widget html.