### PR TITLE
Feature/template functions

### DIFF
--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -242,7 +242,7 @@ jQuery(document).ready(function ($) {
 	});
 
 	// Update shipping (v2)
-	$(document).on('change', 'table#kco-totals #kco-page-shipping input[type="radio"]', function (event) {
+	$(document).on('change', 'table#kco-totals #kco-page-shipping input[type="radio"], .woocommerce-checkout-review-order-table #shipping_method input[type="radio"]', function (event) {
 		if (!performingAjax) {
 			performingAjax = true;
 			blockCartWidget();

--- a/classes/class-klarna-shortcodes.php
+++ b/classes/class-klarna-shortcodes.php
@@ -232,6 +232,7 @@ class WC_Gateway_Klarna_Shortcodes {
 		$atts = shortcode_atts( array(
 			'col'           => '',
 			'order_note'    => '',
+			'coupon_form'   => '',
 			'hide_columns'  => '',
 			'only_shipping' => ''
 		), $atts );
@@ -288,7 +289,7 @@ class WC_Gateway_Klarna_Shortcodes {
 			$atts = WC()->session->get( 'kco_widget_atts' );
 		} else {
 			// Set empty defaults
-			$atts = array( 'order_note' => '', 'hide_columns' => '', 'only_shipping' => '' );
+			$atts = array( 'order_note' => '', 'coupon_form' => '', 'hide_columns' => '', 'only_shipping' => '' );
 		}
 
 		do_action( 'kco_widget_before_calculation', $atts );
@@ -309,7 +310,9 @@ class WC_Gateway_Klarna_Shortcodes {
 			<?php do_action( 'kco_widget_before_coupon', $atts ); ?>
 
 			<!-- Coupons -->
-			<?php woocommerce_checkout_coupon_form(); ?>
+			<?php if ( 'hide' !== $atts['coupon_form'] ) { ?>
+				<?php woocommerce_checkout_coupon_form(); ?>
+			<?php }; ?>
 
 			<?php do_action( 'kco_widget_before_cart_items', $atts ); ?>
 

--- a/classes/class-klarna-shortcodes.php
+++ b/classes/class-klarna-shortcodes.php
@@ -274,7 +274,6 @@ class WC_Gateway_Klarna_Shortcodes {
 	 * @return string
 	 */
 	function klarna_checkout_get_kco_widget_html( $atts = null ) {
-		global $woocommerce;
 		ob_start();
 
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
@@ -282,20 +281,20 @@ class WC_Gateway_Klarna_Shortcodes {
 		}
 
 		if ( $atts ) {
-			// When the shortcode is first rendered we store attributes into session
+			// When the shortcode is first rendered we store attributes into session.
 			WC()->session->set( 'kco_widget_atts', $atts );
 		} else if ( WC()->session->get( 'kco_widget_atts' ) ) {
-			// Then we pull them from the session on widget refresh
+			// Then we pull them from the session on widget refresh.
 			$atts = WC()->session->get( 'kco_widget_atts' );
 		} else {
-			// Set empty defaults
+			// Set empty defaults.
 			$atts = array( 'order_note' => '', 'coupon_form' => '', 'hide_columns' => '', 'only_shipping' => '' );
 		}
 
 		do_action( 'kco_widget_before_calculation', $atts );
-		$woocommerce->cart->calculate_shipping();
-		$woocommerce->cart->calculate_fees();
-		$woocommerce->cart->calculate_totals();
+		WC()->cart->calculate_shipping();
+		WC()->cart->calculate_fees();
+		WC()->cart->calculate_totals();
 		?>
 
 		<?php if ( 'yes' == $atts['only_shipping'] ) { ?>
@@ -308,49 +307,52 @@ class WC_Gateway_Klarna_Shortcodes {
 			</div>
 		<?php }  else { ?>
 			<?php do_action( 'kco_widget_before_coupon', $atts ); ?>
-
+			
 			<!-- Coupons -->
 			<?php if ( 'hide' !== $atts['coupon_form'] ) { ?>
 				<?php woocommerce_checkout_coupon_form(); ?>
 			<?php }; ?>
 
-			<?php do_action( 'kco_widget_before_cart_items', $atts ); ?>
+			<?php if ( apply_filters( 'kco_cart_widget_use_woocommerce_order_review', true ) ) { ?>
+				<?php woocommerce_order_review(); ?>
+			<?php } else { ?>
 
-			<!-- Cart items -->
-			<?php do_action( 'klarna_checkout_get_cart_contents_html', $atts );?>
+				<?php do_action( 'kco_widget_before_cart_items', $atts ); ?>
 
-			<?php do_action( 'kco_widget_before_totals', $atts ); ?>
+				<!-- Cart items -->
+				<?php do_action( 'klarna_checkout_get_cart_contents_html', $atts );?>
 
-			<!-- Totals -->
-			<div>
-				<table id="kco-totals">
-					<tbody>
-					<tr id="kco-page-subtotal">
-						<td class="kco-col-desc"><?php _e( 'Subtotal', 'woocommerce-gateway-klarna' ); ?></td>
-						<td id="kco-page-subtotal-amount" class="kco-col-number kco-rightalign"><span
-								class="amount"><?php echo $woocommerce->cart->get_cart_subtotal(); ?></span></td>
-					</tr>
+				<?php do_action( 'kco_widget_before_totals', $atts ); ?>
 
-					<?php echo $this->klarna_checkout_get_shipping_options_row_html(); // Shipping options ?>
+				<!-- Totals -->
+				<div>
+					<table id="kco-totals">
+						<tbody>
+						<tr id="kco-page-subtotal">
+							<td class="kco-col-desc"><?php _e( 'Subtotal', 'woocommerce-gateway-klarna' ); ?></td>
+							<td id="kco-page-subtotal-amount" class="kco-col-number kco-rightalign"><span
+									class="amount"><?php echo WC()->cart->get_cart_subtotal(); ?></span></td>
+						</tr>
 
-					<?php echo $this->klarna_checkout_get_fees_row_html(); // Fees ?>
+						<?php echo $this->klarna_checkout_get_shipping_options_row_html(); // Shipping options ?>
 
-					<?php echo $this->klarna_checkout_get_coupon_rows_html(); // Coupons ?>
+						<?php echo $this->klarna_checkout_get_fees_row_html(); // Fees ?>
 
-					<?php echo $this->klarna_checkout_get_taxes_rows_html(); // Taxes ?>
-					
-					<?php do_action( 'kco_widget_before_cart_total', $atts ); ?>
-					
-					<?php /* Cart total */ ?>
-					<tr id="kco-page-total">
-						<td class="kco-bold"><?php _e( 'Total', 'woocommerce-gateway-klarna' ); ?></a></td>
-						<td id="kco-page-total-amount" class="kco-rightalign kco-bold"><span
-								class="amount"><?php echo $woocommerce->cart->get_total(); ?></span></td>
-					</tr>
-					<?php /* Cart total */ ?>
-					</tbody>
-				</table>
-			</div>
+						<?php echo $this->klarna_checkout_get_coupon_rows_html(); // Coupons ?>
+
+						<?php echo $this->klarna_checkout_get_taxes_rows_html(); // Taxes ?>
+
+						<?php do_action( 'kco_widget_before_cart_total', $atts ); ?>
+
+						<tr id="kco-page-total">
+							<td class="kco-bold"><?php _e( 'Total', 'woocommerce-gateway-klarna' ); ?></a></td>
+							<td id="kco-page-total-amount" class="kco-rightalign kco-bold"><span
+									class="amount"><?php echo WC()->cart->get_total(); ?></span></td>
+						</tr>
+						</tbody>
+					</table>
+				</div>
+			<?php }  ?>
 
 			<?php do_action( 'kco_widget_before_order_note', $atts ); ?>
 

--- a/classes/class-klarna-shortcodes.php
+++ b/classes/class-klarna-shortcodes.php
@@ -314,7 +314,7 @@ class WC_Gateway_Klarna_Shortcodes {
 			<?php do_action( 'kco_widget_before_cart_items', $atts ); ?>
 
 			<!-- Cart items -->
-			<?php echo $this->klarna_checkout_get_cart_contents_html( $atts ); ?>
+			<?php do_action( 'klarna_checkout_get_cart_contents_html', $atts );?>
 
 			<?php do_action( 'kco_widget_before_totals', $atts ); ?>
 
@@ -373,108 +373,7 @@ class WC_Gateway_Klarna_Shortcodes {
 
 		return ob_get_clean();
 	}
-
-
-	/**
-	 * Gets cart contents as formatted HTML.
-	 * Used in KCO widget.
-	 *
-	 * @since  2.0
-	 **/
-	function klarna_checkout_get_cart_contents_html( $atts ) {
-		global $woocommerce;
-
-		ob_start();
-		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
-			define( 'WOOCOMMERCE_CART', true );
-		}
-		$woocommerce->cart->calculate_shipping();
-		$woocommerce->cart->calculate_fees();
-		$woocommerce->cart->calculate_totals();
-
-
-		$hide_columns = array();
-		if ( '' != $atts['hide_columns'] ) {
-			$hide_columns = explode( ',', $atts['hide_columns'] );
-		}
-		?>
-		<div>
-			<div id="klarna_checkout_coupon_result"></div>
-			<table id="klarna-checkout-cart">
-				<tbody>
-				<tr>
-					<?php if ( ! in_array( 'remove', $hide_columns ) ) { ?>
-						<th class="product-remove kco-leftalign"></th>
-					<?php } ?>
-					<th class="product-name kco-leftalign"><?php _e( 'Product', 'woocommerce-gateway-klarna' ); ?></th>
-					<?php if ( ! in_array( 'price', $hide_columns ) ) { ?>
-						<th class="product-price kco-centeralign"><?php _e( 'Price', 'woocommerce-gateway-klarna' ); ?></th>
-					<?php } ?>
-					<th class="product-quantity kco-centeralign"><?php _e( 'Quantity', 'woocommerce-gateway-klarna' ); ?></th>
-					<th class="product-total kco-rightalign"><?php _e( 'Total', 'woocommerce-gateway-klarna' ); ?></th>
-				</tr>
-				<?php
-				// Cart items
-				foreach ( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-					$_product = $cart_item['data'];
-					echo '<tr>';
-					if ( ! in_array( 'remove', $hide_columns ) ) {
-						echo '<td class="kco-product-remove kco-leftalign"><a href="#">x</a></td>';
-					}
-					echo '<td class="product-name kco-leftalign">';
-					if ( apply_filters( 'kco_show_cart_widget_thumbnails', false ) ) {
-						$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
-						if ( ! $_product->is_visible() ) {
-							echo $thumbnail;
-						} else {
-							printf( '<a href="%s">%s</a>', $_product->get_permalink( $cart_item ), $thumbnail );
-						}
-					}
-
-					if ( version_compare( WOOCOMMERCE_VERSION, '3.0', '<' ) ) {
-						$product_name = $_product->get_title();
-					} else {
-						$product_name = $_product->get_name();
-					}
-
-					if ( ! $_product->is_visible() ) {
-						echo apply_filters( 'woocommerce_cart_item_name', $product_name, $cart_item, $cart_item_key ) . '&nbsp;';
-					} else {
-						echo apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s </a>', $_product->get_permalink( $cart_item ), $product_name ), $cart_item, $cart_item_key );
-					}
-					// Meta data
-					echo $woocommerce->cart->get_item_data( $cart_item );
-					echo '</td>';
-					if ( ! in_array( 'price', $hide_columns ) ) {
-						echo '<td class="product-price kco-centeralign"><span class="amount">';
-						echo $woocommerce->cart->get_product_price( $_product );
-						echo '</span></td>';
-					}
-					echo '<td class="product-quantity kco-centeralign" data-cart_item_key="' . $cart_item_key . '">';
-					if ( $_product->is_sold_individually() ) {
-						$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', esc_attr( $cart_item_key ) );
-					} else {
-						$product_quantity = woocommerce_quantity_input( array(
-							'input_name'  => "cart[{$cart_item_key}][qty]",
-							'input_value' => $cart_item['quantity'],
-							'max_value'   => $_product->backorders_allowed() ? '' : $_product->get_stock_quantity(),
-							'min_value'   => '1'
-						), $_product, false );
-					}
-					echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item );
-					echo '</td>';
-					echo '<td class="product-total kco-rightalign"><span class="amount">';
-					echo apply_filters( 'woocommerce_cart_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key );
-					echo '</span></td>';
-					echo '</tr>';
-				}
-				?>
-				</tbody>
-			</table>
-		</div>
-		<?php
-		return ob_get_clean();
-	}
+	
 
 	/**
 	 *

--- a/includes/klarna-template-functions.php
+++ b/includes/klarna-template-functions.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Klarna Template Functions
+ *
+ * Functions for the templating system.
+ *
+ * @author   Krokedil
+ * @package  Klarna/Functions
+ * @since 	 2.4.0
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Gets cart contents as formatted HTML.
+ * Used in KCO widget.
+ *
+ * @since  2.4.0
+ **/
+if ( ! function_exists( 'klarna_checkout_template_get_cart_contents_html' ) ) {
+	function klarna_checkout_template_get_cart_contents_html( $atts ) {
+		global $woocommerce;
+	
+		//ob_start();
+		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
+			define( 'WOOCOMMERCE_CART', true );
+		}
+		$woocommerce->cart->calculate_shipping();
+		$woocommerce->cart->calculate_fees();
+		$woocommerce->cart->calculate_totals();
+	
+	
+		$hide_columns = array();
+		if ( '' != $atts['hide_columns'] ) {
+			$hide_columns = explode( ',', $atts['hide_columns'] );
+		}
+		?>
+		<div>
+			<div id="klarna_checkout_coupon_result"></div>
+			<table id="klarna-checkout-cart">
+				<tbody>
+				<tr>
+					<?php if ( ! in_array( 'remove', $hide_columns ) ) { ?>
+						<th class="product-remove kco-leftalign"></th>
+					<?php } ?>
+					<th class="product-name kco-leftalign"><?php _e( 'Product', 'woocommerce-gateway-klarna' ); ?></th>
+					<?php if ( ! in_array( 'price', $hide_columns ) ) { ?>
+						<th class="product-price kco-centeralign"><?php _e( 'Price', 'woocommerce-gateway-klarna' ); ?></th>
+					<?php } ?>
+					<th class="product-quantity kco-centeralign"><?php _e( 'Quantity', 'woocommerce-gateway-klarna' ); ?></th>
+					<th class="product-total kco-rightalign"><?php _e( 'Total', 'woocommerce-gateway-klarna' ); ?></th>
+				</tr>
+				<?php
+				// Cart items
+				foreach ( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
+					$_product = $cart_item['data'];
+					echo '<tr>';
+					if ( ! in_array( 'remove', $hide_columns ) ) {
+						echo '<td class="kco-product-remove kco-leftalign"><a href="#">x</a></td>';
+					}
+					echo '<td class="product-name kco-leftalign">';
+					if ( apply_filters( 'kco_show_cart_widget_thumbnails', false ) ) {
+						$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
+						if ( ! $_product->is_visible() ) {
+							echo $thumbnail;
+						} else {
+							printf( '<a href="%s">%s</a>', $_product->get_permalink( $cart_item ), $thumbnail );
+						}
+					}
+	
+					if ( ! $_product->is_visible() ) {
+						echo apply_filters( 'woocommerce_cart_item_name', $_product->get_title(), $cart_item, $cart_item_key ) . '&nbsp;';
+					} else {
+						echo apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s </a>', $_product->get_permalink( $cart_item ), $_product->get_title() ), $cart_item, $cart_item_key );
+					}
+					// Meta data
+					echo $woocommerce->cart->get_item_data( $cart_item );
+					echo '</td>';
+					if ( ! in_array( 'price', $hide_columns ) ) {
+						echo '<td class="product-price kco-centeralign"><span class="amount">';
+						echo $woocommerce->cart->get_product_price( $_product );
+						echo '</span></td>';
+					}
+					echo '<td class="product-quantity kco-centeralign" data-cart_item_key="' . $cart_item_key . '">';
+					if ( $_product->is_sold_individually() ) {
+						$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', esc_attr( $cart_item_key ) );
+					} else {
+						$product_quantity = woocommerce_quantity_input( array(
+							'input_name'  => "cart[{$cart_item_key}][qty]",
+							'input_value' => $cart_item['quantity'],
+							'max_value'   => $_product->backorders_allowed() ? '' : $_product->get_stock_quantity(),
+							'min_value'   => '1'
+						), $_product, false );
+					}
+					echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item );
+					echo '</td>';
+					echo '<td class="product-total kco-rightalign"><span class="amount">';
+					echo apply_filters( 'woocommerce_cart_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key );
+					echo '</span></td>';
+					echo '</tr>';
+				}
+				?>
+				</tbody>
+			</table>
+		</div>
+		<?php
+	}
+}

--- a/includes/klarna-template-functions.php
+++ b/includes/klarna-template-functions.php
@@ -4,12 +4,13 @@
  *
  * Functions for the templating system.
  *
- * @author   Krokedil
- * @package  Klarna/Functions
- * @since 	 2.4.0
+ * @author  Krokedil
+ * @package Klarna/Functions
+ * @since   2.4.0
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
@@ -17,22 +18,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Used in KCO widget.
  *
  * @since  2.4.0
- **/
+ */
+
 if ( ! function_exists( 'klarna_checkout_template_get_cart_contents_html' ) ) {
+	/**
+	 * Display cart contents.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 */
 	function klarna_checkout_template_get_cart_contents_html( $atts ) {
-		global $woocommerce;
-	
-		//ob_start();
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );
 		}
-		$woocommerce->cart->calculate_shipping();
-		$woocommerce->cart->calculate_fees();
-		$woocommerce->cart->calculate_totals();
-	
-	
+
+		WC()->cart->calculate_shipping();
+		WC()->cart->calculate_fees();
+		WC()->cart->calculate_totals();
+
 		$hide_columns = array();
-		if ( '' != $atts['hide_columns'] ) {
+		if ( '' !== $atts['hide_columns'] ) {
 			$hide_columns = explode( ',', $atts['hide_columns'] );
 		}
 		?>
@@ -41,25 +45,28 @@ if ( ! function_exists( 'klarna_checkout_template_get_cart_contents_html' ) ) {
 			<table id="klarna-checkout-cart">
 				<tbody>
 				<tr>
-					<?php if ( ! in_array( 'remove', $hide_columns ) ) { ?>
+					<?php if ( ! in_array( 'remove', $hide_columns, true ) ) { ?>
 						<th class="product-remove kco-leftalign"></th>
 					<?php } ?>
 					<th class="product-name kco-leftalign"><?php _e( 'Product', 'woocommerce-gateway-klarna' ); ?></th>
-					<?php if ( ! in_array( 'price', $hide_columns ) ) { ?>
+					<?php if ( ! in_array( 'price', $hide_columns, true ) ) { ?>
 						<th class="product-price kco-centeralign"><?php _e( 'Price', 'woocommerce-gateway-klarna' ); ?></th>
 					<?php } ?>
 					<th class="product-quantity kco-centeralign"><?php _e( 'Quantity', 'woocommerce-gateway-klarna' ); ?></th>
 					<th class="product-total kco-rightalign"><?php _e( 'Total', 'woocommerce-gateway-klarna' ); ?></th>
 				</tr>
 				<?php
-				// Cart items
-				foreach ( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
+				// Cart items.
+				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 					$_product = $cart_item['data'];
 					echo '<tr>';
-					if ( ! in_array( 'remove', $hide_columns ) ) {
+
+					if ( ! in_array( 'remove', $hide_columns, true ) ) {
 						echo '<td class="kco-product-remove kco-leftalign"><a href="#">x</a></td>';
 					}
+
 					echo '<td class="product-name kco-leftalign">';
+
 					if ( apply_filters( 'kco_show_cart_widget_thumbnails', false ) ) {
 						$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
 						if ( ! $_product->is_visible() ) {
@@ -68,21 +75,25 @@ if ( ! function_exists( 'klarna_checkout_template_get_cart_contents_html' ) ) {
 							printf( '<a href="%s">%s</a>', $_product->get_permalink( $cart_item ), $thumbnail );
 						}
 					}
-	
+
 					if ( ! $_product->is_visible() ) {
 						echo apply_filters( 'woocommerce_cart_item_name', $_product->get_title(), $cart_item, $cart_item_key ) . '&nbsp;';
 					} else {
 						echo apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s </a>', $_product->get_permalink( $cart_item ), $_product->get_title() ), $cart_item, $cart_item_key );
 					}
-					// Meta data
-					echo $woocommerce->cart->get_item_data( $cart_item );
+
+					// Meta data.
+					echo WC()->cart->get_item_data( $cart_item );
 					echo '</td>';
-					if ( ! in_array( 'price', $hide_columns ) ) {
+
+					if ( ! in_array( 'price', $hide_columns, true ) ) {
 						echo '<td class="product-price kco-centeralign"><span class="amount">';
-						echo $woocommerce->cart->get_product_price( $_product );
+						echo WC()->cart->get_product_price( $_product );
 						echo '</span></td>';
 					}
+
 					echo '<td class="product-quantity kco-centeralign" data-cart_item_key="' . $cart_item_key . '">';
+
 					if ( $_product->is_sold_individually() ) {
 						$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', esc_attr( $cart_item_key ) );
 					} else {
@@ -93,13 +104,14 @@ if ( ! function_exists( 'klarna_checkout_template_get_cart_contents_html' ) ) {
 							'min_value'   => '1'
 						), $_product, false );
 					}
+
 					echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item );
 					echo '</td>';
 					echo '<td class="product-total kco-rightalign"><span class="amount">';
-					echo apply_filters( 'woocommerce_cart_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key );
+					echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key );
 					echo '</span></td>';
 					echo '</tr>';
-				}
+				} // End foreach().
 				?>
 				</tbody>
 			</table>

--- a/includes/klarna-template-hooks.php
+++ b/includes/klarna-template-hooks.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Klarna Template Hooks
+ *
+ * Action/filter hooks used for Klarna functions/templates.
+ *
+ * @author 		Krokedil
+ * @package 	Klarna/Templates
+ * @since     	2.4.0
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Cart contents.
+ *
+ * @see klarna_checkout_template_get_cart_contents_html()
+ */
+add_action( 'klarna_checkout_get_cart_contents_html', 'klarna_checkout_template_get_cart_contents_html', 10 );

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -216,6 +216,7 @@ function init_klarna_gateway() {
 	require_once 'classes/class-klarna-checkout.php';
 	require_once 'classes/class-klarna-shortcodes.php';
 	require_once 'classes/class-klarna-validate.php';
+	require_once 'includes/klarna-template-hooks.php';
 
 	// Send customer and merchant emails for KCO Incomplete > Processing status change
 
@@ -343,7 +344,15 @@ if ( ! empty( $_POST ) ) {
 	add_action( 'admin_init', 'klarna_checkout_admin_error_notices' );
 }
 
+/**
+ * Function used to Init Klarna Template Functions - This makes them pluggable by plugins and themes.
+ */
+add_action( 'after_setup_theme', 'wc_klarna_include_template_functions', 11 );
+function wc_klarna_include_template_functions() {
+	include_once( 'includes/klarna-template-functions.php' );
+}
 
+			
 // Check if is_order_received_page function needs to be overwritten
 $checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
 $should_filter = isset( $checkout_settings['filter_is_order_received'] ) ? $checkout_settings['filter_is_order_received'] : 'no';


### PR DESCRIPTION
This PR makes it possible to change the markup of the cart contents html from another plugin/theme. This is done by moving the _klarna_checkout_get_cart_contents_html_ function outside of the shortcode class and making it pluggable.

The new _klarna_checkout_template_get_cart_contents_html_ (introduced in klarna-template-functions.php and executed from `do_action( 'klarna_checkout_get_cart_contents_html', $atts )` in the shortcode class and `add_action( 'klarna_checkout_get_cart_contents_html', 'klarna_checkout_template_get_cart_contents_html', 10 ) ` in klarna-template-hooks.php) is added via after_setup_theme with the priority of 11, which means that themes can replace the function by using the after_setup_theme hook from their functions.php (or similar).

In this PR I've also added a parameter to the shortcode attributes to be able to hide the coupon form if needed.