### PR TITLE
Only send woocommerce_thankyou once

### DIFF
--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -139,7 +139,10 @@ do_action( 'klarna_before_kco_confirmation', $order_id, $klarna_order );
 echo $snippet;
 
 do_action( 'klarna_after_kco_confirmation', $order_id, $klarna_order );
-do_action( 'woocommerce_thankyou', $order_id );
+
+if ( ! did_action( 'woocommerce_thankyou' ) ) {
+	do_action( 'woocommerce_thankyou', $order_id );
+}
 
 // Clear session and empty cart.
 WC()->session->__unset( 'klarna_checkout' );


### PR DESCRIPTION
If you override the WooCommece checkout page with the klarna checkout page the thankyou hook triggers twice.

### Steps to reproduce:
1. Set the klarna checkout page to the same URL as the woocommerce checkout page. 
2. Make a purchase. 
3. `woocommerce_thankyou` gets triggered twice.