### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,10 @@
 {
+	"name"       : "pelmered/woocommerce-gateway-klarna",
+	"description": "A Klarna payments integration for WooCommerce.",
+	"homepage"   : "https://krokedil.com/klarna",
+	"keywords"    : ["WooCommerce", "Klarna", "Gateway", "Klarna checkout"],
+	"type"       : "wordpress-plugin",
+	"license"    : "GPL-3.0",
 	"require": {
 		"klarna/checkout": "4.0",
 		"klarna/kco_rest": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name"       : "pelmered/woocommerce-gateway-klarna",
+	"name"       : "krokedil/woocommerce-gateway-klarna",
 	"description": "A Klarna payments integration for WooCommerce.",
 	"homepage"   : "https://krokedil.com/klarna",
 	"keywords"    : ["WooCommerce", "Klarna", "Gateway", "Klarna checkout"],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name"       : "krokedil/woocommerce-gateway-klarna",
 	"description": "A Klarna payments integration for WooCommerce.",
 	"homepage"   : "https://krokedil.com/klarna",
-	"keywords"    : ["WooCommerce", "Klarna", "Gateway", "Klarna checkout"],
+	"keywords"   : ["WooCommerce", "Klarna", "Gateway", "Klarna checkout"],
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-3.0",
 	"require": {


### PR DESCRIPTION
This will add composer support. Please add the repository to https://packagist.org/ as well so we can download this plugin with composer without friction. 

Just `composer require "krokedil/woocommerce-gateway-klarna"` would be enough to install this plugin if you add it to Packagist.

Also, feel free to add author information in the `composer.json` as you see fit. 

Would be great if you could accept this pull request ASAP. Thanks! :)