### PR TITLE
Add woocommerce_cart_item_visible filter to cart

### DIFF
--- a/includes/klarna-template-functions.php
+++ b/includes/klarna-template-functions.php
@@ -58,59 +58,61 @@ if ( ! function_exists( 'klarna_checkout_template_get_cart_contents_html' ) ) {
 				<?php
 				// Cart items.
 				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					$_product = $cart_item['data'];
-					echo '<tr>';
+					if ( apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+						$_product = $cart_item['data'];
+						echo '<tr>';
 
-					if ( ! in_array( 'remove', $hide_columns, true ) ) {
-						echo '<td class="kco-product-remove kco-leftalign"><a href="#">x</a></td>';
-					}
-
-					echo '<td class="product-name kco-leftalign">';
-
-					if ( apply_filters( 'kco_show_cart_widget_thumbnails', false ) ) {
-						$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
-						if ( ! $_product->is_visible() ) {
-							echo $thumbnail;
-						} else {
-							printf( '<a href="%s">%s</a>', $_product->get_permalink( $cart_item ), $thumbnail );
+						if ( ! in_array( 'remove', $hide_columns, true ) ) {
+							echo '<td class="kco-product-remove kco-leftalign"><a href="#">x</a></td>';
 						}
-					}
 
-					if ( ! $_product->is_visible() ) {
-						echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;';
-					} else {
-						echo apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s </a>', $_product->get_permalink( $cart_item ), $_product->get_name() ), $cart_item, $cart_item_key );
-					}
+						echo '<td class="product-name kco-leftalign">';
 
-					// Meta data.
-					echo WC()->cart->get_item_data( $cart_item );
-					echo '</td>';
+						if ( apply_filters( 'kco_show_cart_widget_thumbnails', false ) ) {
+							$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
+							if ( ! $_product->is_visible() ) {
+								echo $thumbnail;
+							} else {
+								printf( '<a href="%s">%s</a>', $_product->get_permalink( $cart_item ), $thumbnail );
+							}
+						}
 
-					if ( ! in_array( 'price', $hide_columns, true ) ) {
-						echo '<td class="product-price kco-centeralign"><span class="amount">';
-						echo WC()->cart->get_product_price( $_product );
+						if ( ! $_product->is_visible() ) {
+							echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;';
+						} else {
+							echo apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s </a>', $_product->get_permalink( $cart_item ), $_product->get_name() ), $cart_item, $cart_item_key );
+						}
+
+						// Meta data.
+						echo WC()->cart->get_item_data( $cart_item );
+						echo '</td>';
+
+						if ( ! in_array( 'price', $hide_columns, true ) ) {
+							echo '<td class="product-price kco-centeralign"><span class="amount">';
+							echo WC()->cart->get_product_price( $_product );
+							echo '</span></td>';
+						}
+
+						echo '<td class="product-quantity kco-centeralign" data-cart_item_key="' . $cart_item_key . '">';
+
+						if ( $_product->is_sold_individually() ) {
+							$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', esc_attr( $cart_item_key ) );
+						} else {
+							$product_quantity = woocommerce_quantity_input( array(
+								'input_name'  => "cart[{$cart_item_key}][qty]",
+								'input_value' => $cart_item['quantity'],
+								'max_value'   => $_product->backorders_allowed() ? '' : $_product->get_stock_quantity(),
+								'min_value'   => '1'
+							), $_product, false );
+						}
+
+						echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item );
+						echo '</td>';
+						echo '<td class="product-total kco-rightalign"><span class="amount">';
+						echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key );
 						echo '</span></td>';
+						echo '</tr>';
 					}
-
-					echo '<td class="product-quantity kco-centeralign" data-cart_item_key="' . $cart_item_key . '">';
-
-					if ( $_product->is_sold_individually() ) {
-						$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', esc_attr( $cart_item_key ) );
-					} else {
-						$product_quantity = woocommerce_quantity_input( array(
-							'input_name'  => "cart[{$cart_item_key}][qty]",
-							'input_value' => $cart_item['quantity'],
-							'max_value'   => $_product->backorders_allowed() ? '' : $_product->get_stock_quantity(),
-							'min_value'   => '1'
-						), $_product, false );
-					}
-
-					echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item );
-					echo '</td>';
-					echo '<td class="product-total kco-rightalign"><span class="amount">';
-					echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key );
-					echo '</span></td>';
-					echo '</tr>';
 				} // End foreach().
 				?>
 				</tbody>


### PR DESCRIPTION
Add the WooCommerce cart standard filter woocommerce_cart_item_visible. This for example makes it possible to use the products bundle plugin to hide different bundled products in the cart.
