### PR TITLE
Updated order number to get_order_number()

### DIFF
--- a/includes/klarna-wc-30-compatibility-functions.php
+++ b/includes/klarna-wc-30-compatibility-functions.php
@@ -12,8 +12,8 @@
  * @return mixed | WC_Order ID
  */
 function klarna_wc_get_order_id( $order ) {
-	if ( method_exists( $order, 'get_id' ) ) {
-		return $order->get_id();
+	if ( method_exists( $order, 'get_order_number' ) ) {
+		return $order->get_order_number();
 	} else {
 		return $order->id;
 	}


### PR DESCRIPTION
The order number is not the post id, it's an order number. Many plugins modify this number.

Getting the ID rather than the order number causes Klarna to return to WC at the wrong order and leaves orders unfulfilled.

# Thank you for contributing!

Please make sure you are submitting this pull request to `develop` branch of Krokedil's repository:

https://github.com/krokedil/woocommerce-gateway-klarna/tree/develop
