### PR TITLE
2.5.12

### DIFF
--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -243,6 +243,13 @@ jQuery(document).ready(function ($) {
 
 	// Update shipping (v2)
 	$(document).on('change', 'table#kco-totals #kco-page-shipping input[type="radio"], .woocommerce-checkout-review-order-table #shipping_method input[type="radio"]', function (event) {
+		var id = $(this).val(); 
+		update_klarna_shipping( id );
+	});
+	$(document.body).on('klarna_update_shipping', function (event) { 
+		update_klarna_shipping( 'stidner' );
+	});
+	function update_klarna_shipping( id ) {
 		if (!performingAjax) {
 			performingAjax = true;
 			blockCartWidget();
@@ -252,8 +259,7 @@ jQuery(document).ready(function ($) {
 					api.suspend();
 				});
 			}
-
-			new_method = $(this).val();
+			new_method = id;
 			kco_widget = $('#klarna-checkout-widget');
 
 			$(document.body).trigger('kco_widget_update_shipping', new_method);
@@ -269,15 +275,18 @@ jQuery(document).ready(function ($) {
 						nonce: kcoAjax.klarna_checkout_nonce
 					},
 					success: function (response) {
-						$(kco_widget).html(response.data.widget_html);
+						$('#klarna-checkout-widget').html(response.data.widget_html);
 					},
 					error: function (response) {
 						console.log('update shipping AJAX error');
 						console.log(response);
 					},
 					complete: function () {
+						console.log( 'complete' );
 						if (typeof window._klarnaCheckout == 'function') {
+							console.log('klarna if');
 							window._klarnaCheckout(function (api) {
+								console.log('klarnaCheckout window');
 								api.resume();
 							});
 						}
@@ -288,7 +297,7 @@ jQuery(document).ready(function ($) {
 				}
 			);
 		}
-	});
+	}
 
 	// Update cart (v2)
 	$(document).on('change', '.product-quantity input[type=number]', function (event) {
@@ -337,7 +346,7 @@ jQuery(document).ready(function ($) {
 					},
 					success: function (response) {
 						if (response.success) {
-							$(kco_widget).html(response.data.widget_html);
+							$('#klarna-checkout-widget').html(response.data.widget_html);
 						} else {
 							window.location.href = response.data.cart_url;
 						}
@@ -393,7 +402,7 @@ jQuery(document).ready(function ($) {
 						if (0 == response.data.item_count) {
 							location.reload();
 						} else {
-							$(kco_widget).html(response.data.widget_html);
+							$('#klarna-checkout-widget').html(response.data.widget_html);
 							$(item_row).remove();
 
 							if (typeof window._klarnaCheckout != 'function') {
@@ -453,7 +462,7 @@ jQuery(document).ready(function ($) {
 					success: function (response) {
 						if (response.data.coupon_success) {
 							$(input_field).val('');
-							$(kco_widget).html(response.data.widget_html);
+							$('#klarna-checkout-widget').html(response.data.widget_html);
                             $('#klarna_checkout_coupon_result').html('<div class="woocommerce-message" role="alert">' + kcoAjax.coupon_success + '</div>');
 
 							if (typeof window._klarnaCheckout != 'function') {
@@ -514,7 +523,7 @@ jQuery(document).ready(function ($) {
 					},
 					success: function (response) {
 						$(clicked_el).closest('tr').remove();
-						$(kco_widget).html(response.data.widget_html);
+						$('#klarna-checkout-widget').html(response.data.widget_html);
 
 						// Remove WooCommerce notification
 						$('#klarna-checkout-widget .woocommerce-info + .woocommerce-message').remove();
@@ -575,7 +584,10 @@ jQuery(document).ready(function ($) {
 									}
 
 									if ('' != data.email) {
+										console.log('hello world!');
 										kco_widget = $('#klarna-checkout-widget');
+										console.log( 'id ' + $('#klarna-checkout-widget') );
+										console.log( 'var ' + kco_widget );
 
 										$(document.body).trigger('kco_widget_update', data);
 
@@ -599,7 +611,7 @@ jQuery(document).ready(function ($) {
 													return;
 												}
 
-												$(kco_widget).html(response.data.widget_html);
+												$('#klarna-checkout-widget').html(response.data.widget_html);
 												$(document.body).trigger('kco_widget_updated', response);
 												unblockCartWidget();
 
@@ -645,7 +657,7 @@ jQuery(document).ready(function ($) {
 									}
 								})
 									.done(function (response) {
-										$(kco_widget).html(response.data.widget_html);
+										$('#klarna-checkout-widget').html(response.data.widget_html);
 
 										window._klarnaCheckout(function (api) {
 											api.resume();
@@ -707,7 +719,7 @@ jQuery(document).ready(function ($) {
 											nonce: kcoAjax.klarna_checkout_nonce
 										},
 										success: function (response) {
-											$(kco_widget).html(response.data.widget_html);
+											$('#klarna-checkout-widget').html(response.data.widget_html);
 										},
 										error: function (response) {
 											console.log('shipping_address_change AJAX error');
@@ -743,7 +755,7 @@ jQuery(document).ready(function ($) {
 								nonce: kcoAjax.klarna_checkout_nonce
 							},
 							success: function (response) {
-								$(kco_widget).html(response.data.widget_html);
+								$('#klarna-checkout-widget').html(response.data.widget_html);
 							},
 							error: function (response) {
 								console.log('shipping_option_change AJAX error');

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,15 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2018.05.11  - version 2.5.12
+* Tweak		- Added Stidner shipping plugin compatibility support.
+* Tweak		- Add 402 status as post meta klarna_subscription_renewal_status (to be able to query the amount of declined renewal purchases).
+* Fix		- Switched from calculating tax rate to getting the stored tax rate in the order when doing refunds.
+* Fix		- Avoid php error if client_currency (WPML check) doesn’t exist in session.
+* Fix		- Get subscription data from parent order if missing in renewal order.
+* Fix		- Adds order note if customer/user can’t be created on subscription signups.
+* Fix		- Populate Billing company field correct in get address call (KPM).
+
+
 2018.03.23  - version 2.5.11
 * Fix       - Logging improvements to avoid PHP errors.
 

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -645,6 +645,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			$pay_load = $e->getPayload();
 			if( 402 == $e->getCode() ) {
 				$order->add_order_note( sprintf( __( 'Klarna subscription payment failed. Error code: %s. Reason: %s. Payment method: %s.', 'woocommerce-gateway-klarna' ), $e->getCode(), $pay_load['reason'], $pay_load['payment_method']['type'] ) );
+				update_post_meta( $order_id, 'klarna_subscription_renewal_status', $e->getCode() );
 			} else {
 				$internal_message = '';
 				if( isset( $pay_load['internal_message'] ) ) {

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -433,7 +433,9 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		$klarna_recurring_token = get_post_meta( $order_id, '_klarna_recurring_token', true );
 		// If the recurring token isn't stored in the subscription, grab it from parent order.
 		if( empty( $klarna_recurring_token ) ) {
-			$klarna_recurring_token = get_post_meta( $subscription_id, '_klarna_recurring_token', true );
+			$klarna_recurring_token = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_klarna_recurring_token', true );
+			update_post_meta( $order_id, '_klarna_recurring_token', $klarna_recurring_token );
+			update_post_meta( $subscription_id, '_klarna_recurring_token', $klarna_recurring_token );
 		}
 		if( empty( $klarna_recurring_token ) ) {
 			$order->add_order_note( __( 'Klarna recurring token could not be retrieved.', 'woocommerce-gateway-klarna' ) );
@@ -443,11 +445,13 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		$klarna_locale          	= get_post_meta( $order_id, '_klarna_locale', true );
 		// If the locale isn't stored in the subscription, grab it from parent order.
 		if( empty( $klarna_locale ) ) {
-			$klarna_locale = get_post_meta( $subscription_id, '_klarna_locale', true );
+			$klarna_locale = get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_klarna_locale', true );
+			update_post_meta( $subscription_id, '_klarna_locale', $klarna_locale );
 		}
 		if( empty( $klarna_locale ) ) {
 			$klarna_locale = 'en-gb';
 			$order->add_order_note( __( 'Klarna locale could not be retrieved, using English as fallback language.', 'woocommerce-gateway-klarna' ) );
+			update_post_meta( $subscription_id, '_klarna_locale', $klarna_locale );
 		}
 		
 		$klarna_currency        	= get_post_meta( $order_id, '_order_currency', true );
@@ -462,53 +466,53 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		// Billing country - including fallback check
 		$billing_country         	= get_post_meta( $order_id, '_billing_country', true ) ? get_post_meta( $order_id, '_billing_country', true ) : $klarna_country;
 		if( empty( $billing_country ) ) {
-			$billing_country = get_post_meta( $subscription_id, '_billing_country', true );
+			$billing_country = get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_country', true );
 		}
 		
 		// Shipping country - including fallback check
 		$shipping_country         	= get_post_meta( $order_id, '_shipping_country', true ) ? get_post_meta( $order_id, '_shipping_country', true ) : $klarna_country;
 		if( empty( $shipping_country ) ) {
-			$shipping_country = get_post_meta( $subscription_id, '_billing_country', true );
+			$shipping_country = get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_country', true );
 		}
 		
 		// Billing postcode
-		$billing_postcode	= get_post_meta( $order_id, '_billing_postcode', true ) ? get_post_meta( $order_id, '_billing_postcode', true ) : get_post_meta( $subscription_id, '_billing_postcode', true );
+		$billing_postcode	= get_post_meta( $order_id, '_billing_postcode', true ) ? get_post_meta( $order_id, '_billing_postcode', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_postcode', true );
 		
 		// Shipping postcode
-		$shipping_postcode	= get_post_meta( $order_id, '_shipping_postcode', true ) ? get_post_meta( $order_id, '_shipping_postcode', true ) : get_post_meta( $subscription_id, '_shipping_postcode', true );
+		$shipping_postcode	= get_post_meta( $order_id, '_shipping_postcode', true ) ? get_post_meta( $order_id, '_shipping_postcode', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_shipping_postcode', true );
 		
 		// Billing email
-		$billing_email	= get_post_meta( $order_id, '_billing_email', true ) ? get_post_meta( $order_id, '_billing_email', true ) : get_post_meta( $subscription_id, '_billing_email', true );
+		$billing_email	= get_post_meta( $order_id, '_billing_email', true ) ? get_post_meta( $order_id, '_billing_email', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_email', true );
 		
 		// Shipping email
 		$shipping_email	= get_post_meta( $order_id, '_shipping_email', true ) ? get_post_meta( $order_id, '_shipping_email', true ) : $billing_email;
 		
 		// Billing city
-		$billing_city	= get_post_meta( $order_id, '_billing_city', true ) ? get_post_meta( $order_id, '_billing_city', true ) : get_post_meta( $subscription_id, '_billing_city', true );
+		$billing_city	= get_post_meta( $order_id, '_billing_city', true ) ? get_post_meta( $order_id, '_billing_city', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_city', true );
 		
 		// Shipping city
-		$shipping_city	= get_post_meta( $order_id, '_shipping_city', true ) ? get_post_meta( $order_id, '_shipping_city', true ) : get_post_meta( $subscription_id, '_shipping_city', true );
+		$shipping_city	= get_post_meta( $order_id, '_shipping_city', true ) ? get_post_meta( $order_id, '_shipping_city', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_shipping_city', true );
 		
 		// Billing first name
-		$billing_first_name	= get_post_meta( $order_id, '_billing_first_name', true ) ? get_post_meta( $order_id, '_billing_first_name', true ) : get_post_meta( $subscription_id, '_billing_first_name', true );
+		$billing_first_name	= get_post_meta( $order_id, '_billing_first_name', true ) ? get_post_meta( $order_id, '_billing_first_name', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_first_name', true );
 		
 		// Shipping first name
-		$shipping_first_name	= get_post_meta( $order_id, '_shipping_first_name', true ) ? get_post_meta( $order_id, '_shipping_first_name', true ) : get_post_meta( $subscription_id, '_shipping_first_name', true );
+		$shipping_first_name	= get_post_meta( $order_id, '_shipping_first_name', true ) ? get_post_meta( $order_id, '_shipping_first_name', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_shipping_first_name', true );
 		
 		// Billing last name
-		$billing_last_name	= get_post_meta( $order_id, '_billing_last_name', true ) ? get_post_meta( $order_id, '_billing_last_name', true ) : get_post_meta( $subscription_id, '_billing_last_name', true );
+		$billing_last_name	= get_post_meta( $order_id, '_billing_last_name', true ) ? get_post_meta( $order_id, '_billing_last_name', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_last_name', true );
 		
 		// Shipping last name
-		$shipping_last_name	= get_post_meta( $order_id, '_shipping_last_name', true ) ? get_post_meta( $order_id, '_shipping_last_name', true ) : get_post_meta( $subscription_id, '_shipping_last_name', true );
+		$shipping_last_name	= get_post_meta( $order_id, '_shipping_last_name', true ) ? get_post_meta( $order_id, '_shipping_last_name', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_shipping_last_name', true );
 		
 		// Billing address 1
-		$billing_address_1	= get_post_meta( $order_id, '_billing_address_1', true ) ? get_post_meta( $order_id, '_billing_address_1', true ) : get_post_meta( $subscription_id, '_billing_address_1', true );
+		$billing_address_1	= get_post_meta( $order_id, '_billing_address_1', true ) ? get_post_meta( $order_id, '_billing_address_1', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_address_1', true );
 		
 		// Shipping address 1
-		$shipping_address_1	= get_post_meta( $order_id, '_shipping_address_1', true ) ? get_post_meta( $order_id, '_shipping_address_1', true ) : get_post_meta( $subscription_id, '_shipping_address_1', true );
+		$shipping_address_1	= get_post_meta( $order_id, '_shipping_address_1', true ) ? get_post_meta( $order_id, '_shipping_address_1', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_shipping_address_1', true );
 		
 		// Billing phone
-		$billing_phone	= get_post_meta( $order_id, '_billing_phone', true ) ? get_post_meta( $order_id, '_billing_phone', true ) : get_post_meta( $subscription_id, '_billing_phone', true );
+		$billing_phone	= get_post_meta( $order_id, '_billing_phone', true ) ? get_post_meta( $order_id, '_billing_phone', true ) : get_post_meta(  WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_billing_phone', true );
 		
 		// Shipping phone
 		$shipping_phone	= get_post_meta( $order_id, '_shipping_phone', true ) ? get_post_meta( $order_id, '_shipping_phone', true ) : $billing_phone;

--- a/classes/class-klarna-get-address.php
+++ b/classes/class-klarna-get-address.php
@@ -139,11 +139,11 @@ class WC_Klarna_Get_Address {
 					});
 
 					function klarnainfo(type, info, value) {
-
+						
 						if (type == 'company') {
 							var adress = info[0][value];
 							var orgno_getadress = "";
-
+							
 							jQuery("#billing_first_name").val(adress['fname']);
 							jQuery("#billing_last_name").val(adress['lname']);
 							jQuery("#billing_company").val(adress['company']); //.prop( "readonly", true );
@@ -171,6 +171,7 @@ class WC_Klarna_Get_Address {
 
 								jQuery("#billing_first_name").val(adress['fname']); //.prop( "readonly", true );
 								jQuery("#billing_last_name").val(adress['lname']); //.prop( "readonly", true );
+								jQuery("#billing_company").val(adress['company']);
 								jQuery("#billing_address_1").val(adress['street']); //.prop( "readonly", true );
 								jQuery("#billing_address_2").val(adress['careof']);
 								jQuery("#billing_postcode").val(adress['zip']); //.prop( "readonly", true );
@@ -178,6 +179,7 @@ class WC_Klarna_Get_Address {
 
 								jQuery("#shipping_first_name").val(adress['fname']); //.prop( "readonly", true );
 								jQuery("#shipping_last_name").val(adress['lname']); //.prop( "readonly", true );
+								jQuery("#shipping_company").val(adress['company']);
 								jQuery("#shipping_address_1").val(adress['street']); //.prop( "readonly", true );
 								jQuery("#shipping_address_2").val(adress['careof']);
 								jQuery("#shipping_postcode").val(adress['zip']); //.prop( "readonly", true );
@@ -362,7 +364,7 @@ class WC_Klarna_Get_Address {
 				$pcStorage = 'json',          // PClass storage.
 				$pcURI = '/srv/pclasses.json' // PClass storage URI path.
 			);
-
+			
 			$pno_getadress = $_REQUEST['pno_getadress']; // Input var okay.
 			$return        = array();
 
@@ -392,7 +394,7 @@ class WC_Klarna_Get_Address {
 				);
 
 			}
-
+			
 			wp_send_json( $return );
 		} else {
 			echo '';

--- a/classes/class-klarna-order.php
+++ b/classes/class-klarna-order.php
@@ -364,7 +364,11 @@ class WC_Gateway_Klarna_Order {
 			 * If yes, go ahead with good-will refund.
 			 */
 			if ( 1 == count( $order->get_taxes() ) ) {
-				$tax_rate = (int) ($order->get_total_tax() / ( $order->get_total() - $order->get_total_tax() ) * 100);
+				$tax_items = $order->get_items( 'tax' );
+				foreach( $tax_items as $tax_item ) {
+					$rate_id = $tax_item->get_rate_id();
+					$tax_rate = round( intval( WC_Tax::_get_tax_rate( $rate_id )['tax_rate'] ), 0 );
+				}
 				try {
 					$ocr = $klarna->returnAmount( // returns 1 on success
 						$invNo,                // Invoice number

--- a/classes/class-klarna-shortcodes.php
+++ b/classes/class-klarna-shortcodes.php
@@ -251,7 +251,8 @@ class WC_Gateway_Klarna_Shortcodes {
 			'order_note'    => '',
 			'coupon_form'   => '',
 			'hide_columns'  => '',
-			'only_shipping' => ''
+			'only_shipping' => '',
+			'no_shipping'   => '',
 		), $atts );
 
 		$widget_class = '';
@@ -306,9 +307,8 @@ class WC_Gateway_Klarna_Shortcodes {
 			$atts = WC()->session->get( 'kco_widget_atts' );
 		} else {
 			// Set empty defaults.
-			$atts = array( 'order_note' => '', 'coupon_form' => '', 'hide_columns' => '', 'only_shipping' => '' );
+			$atts = array( 'order_note' => '', 'coupon_form' => '', 'hide_columns' => '', 'only_shipping' => '', 'no_shipping' => '' );
 		}
-
 		do_action( 'kco_widget_before_calculation', $atts );
 		WC()->cart->calculate_shipping();
 		WC()->cart->calculate_fees();
@@ -352,7 +352,7 @@ class WC_Gateway_Klarna_Shortcodes {
 									class="amount"><?php echo WC()->cart->get_cart_subtotal(); ?></span></td>
 						</tr>
 
-						<?php echo $this->klarna_checkout_get_shipping_options_row_html(); // Shipping options ?>
+						<?php echo $this->klarna_checkout_get_shipping_options_row_html( $atts ); // Shipping options ?>
 
 						<?php echo $this->klarna_checkout_get_fees_row_html(); // Fees ?>
 
@@ -406,7 +406,10 @@ class WC_Gateway_Klarna_Shortcodes {
 	 *
 	 * @since  2.0
 	 **/
-	function klarna_checkout_get_shipping_options_row_html() {
+	function klarna_checkout_get_shipping_options_row_html( $atts ) {
+		if( 'yes' === $atts['no_shipping'] ) {
+			return null;
+		}
 		ob_start();
 
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
@@ -474,7 +477,7 @@ class WC_Gateway_Klarna_Shortcodes {
 					?>
 				</td>
 				<td id="kco-page-shipping-total" class="kco-rightalign">
-					<?php
+				<?php
 					// @TODO: Check available methods in all packages, not just last one.
 					if ( empty( $available_methods ) && WC()->cart->needs_shipping() ) {
 					    if ( '' === WC()->customer->get_shipping_country() || '' === WC()->customer->get_shipping_postcode() ) {

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -1032,7 +1032,7 @@ class WC_Gateway_Klarna_K2WC {
 					}
 					$order->add_order_note( sprintf( __( 'New customer created (user ID %s).', 'klarna' ), $customer_id, $klarna_order['id'] ) );
 				} elseif ( is_wp_error( $customer_id ) ) {
-					//$this->klarna_log->add( 'klarna', 'Error creating new customer account: ' . $customer_id->get_error_code() . ' - ' . $customer_id->get_error_message() );
+					$order->add_order_note( sprintf( __( 'Error creating new customer account: %s', 'klarna' ), var_export($customer_id, true) ) );
 				}
 			}
 		}

--- a/includes/variables-checkout.php
+++ b/includes/variables-checkout.php
@@ -125,7 +125,7 @@ endif;
 
 // We need to check if WPML is active
 if ( ! is_admin() ) {
-	if ( null !== WC()->session && WC()->session->get( 'client_currency' ) ) {
+	if( method_exists( WC()->session, 'client_currency' ) ) {
 		$customer_selected_currency = WC()->session->get( 'client_currency' );
 	} else {
 		$customer_selected_currency = get_woocommerce_currency();

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: krokedil, niklashogefjord, slobodanmanic
 Tags: ecommerce, e-commerce, woocommerce, klarna
 Requires at least: 4.2
-Tested up to: 4.9.4
-Requires WooCommerce at least: 3.0
-Tested WooCommerce up to: 3.3.4
+Tested up to: 4.9.5
+WC requires at least: 3.0.0
+WC tested up to: 3.3.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.5.11
+ * Version:         2.5.12
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.5.11' );
+	define( 'WC_KLARNA_VER', '2.5.12' );
 }
 
 /**


### PR DESCRIPTION
* Tweak - Added Stidner shipping plugin compatibility support.
* Tweak - Add 402 status as post meta klarna_subscription_renewal_status (to be able to query the amount of declined renewal purchases).
* Fix - Switched from calculating tax rate to getting the stored tax rate in the order when doing refunds.
* Fix - Avoid php error if client_currency (WPML check) doesn’t exist in session.
* Fix	- Get subscription data from parent order if missing in renewal order.
* Fix	- Adds order note if customer/user can’t be created on subscription signups.
* Fix	- Populate Billing company field correct in get address call (KPM).