### PR TITLE
Escaping $event['data'] in logger.

### DIFF
--- a/vendor/krokedil/krokedil-logger/src/krokedil-order-event-log.php
+++ b/vendor/krokedil/krokedil-logger/src/krokedil-order-event-log.php
@@ -147,7 +147,7 @@ function krokedil_meta_contents() {
 		echo '<h4>' . $event['title'] . '</h4>';
 		echo '<h5 class="krokedil_timestamp" data-event-nr="' . $i . '"><a href="#krokedil_event_nr_' . $i . '">Time: ' . $event['timestamp'] . '</a></h5>';
 		echo '</div>';
-		echo '<div class="krokedil_json krokedil_hidden" id="krokedil_event_nr_' . $i . '">' . json_encode( $event['data'] ) . '</div>';
+		echo '<div class="krokedil_json krokedil_hidden" id="krokedil_event_nr_' . $i . '">' . esch_html( json_encode( $event['data'] ) ) . '</div>';
 		echo '</div>';
 	}
 	echo '<small>Version of plugin used for order: ' . krokedil_get_order_version() . '</small>';


### PR DESCRIPTION
We're experiencing an issue where the metabox containing Klarna Events breaks the admin page of an order due to invalid html outputted resulting in that any adjacent content (other metaboxes, admin footer etc.) is wrapped inside the Klarna events metabox.

# Thank you for contributing!

Please make sure you are submitting this pull request to `develop` branch of Krokedil's repository:

https://github.com/krokedil/woocommerce-gateway-klarna/tree/develop
