### PR TITLE
2.5.14

### DIFF
--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -284,7 +284,6 @@ jQuery(document).ready(function ($) {
 					complete: function () {
 						console.log( 'complete' );
 						if (typeof window._klarnaCheckout == 'function') {
-							console.log('klarna if');
 							window._klarnaCheckout(function (api) {
 								console.log('klarnaCheckout window');
 								api.resume();
@@ -584,7 +583,6 @@ jQuery(document).ready(function ($) {
 									}
 
 									if ('' != data.email) {
-										console.log('hello world!');
 										kco_widget = $('#klarna-checkout-widget');
 										console.log( 'id ' + $('#klarna-checkout-widget') );
 										console.log( 'var ' + kco_widget );

--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -246,8 +246,8 @@ jQuery(document).ready(function ($) {
 		var id = $(this).val(); 
 		update_klarna_shipping( id );
 	});
-	$(document.body).on('klarna_update_shipping', function (event) { 
-		update_klarna_shipping( 'stidner' );
+	$(document.body).on('klarna_update_shipping', function (event, id) { 
+		update_klarna_shipping( id );
 	});
 	function update_klarna_shipping( id ) {
 		if (!performingAjax) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2018.07.30	- version 2.5.15
+* Tweak		- Move unset kco sessions to maybe_clear_kco_sessions() function.
+* Tweak		- Added supports subscription_payment_method_change_admin for KCO.
+* Tweak		- Updated JS event klarna_update_shipping in KCO page so other plugins can update shipping method info and trigger that update to Klarna.
+* Fix		- Fixes so HTML tags being stripped ocht in KCO logs.
+* Fix		- Fixes problem with order started with Swish as payment method but then cancelling and switch to KCO.
+* Fix		- Don't change to KCO checkout url if customer is making a subscription switch (then use the regular checkout instead).
+* Fix		- Added check for subscription limit for customer in validation callback.
+
 2018.05.24  - version 2.5.14
 * Feature	- Added support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.
 * Fix		- Added try catch to parse json in Krokedil logger on order page.

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -133,6 +133,35 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 
 		// Use an existing order when paying for a manual subscription renewal via "Pay Order" page
 		add_action( 'template_redirect', array( $this, 'use_ongoing_order_for_kco' ) );
+
+		// Maybe remove KCO sessions on thank you page. Check is performed even i KCO is the selected payment method or not.
+		add_action( 'woocommerce_thankyou', array( $this, 'maybe_clear_kco_sessions' ), 20 );
+	}
+
+	/**
+	 * Function maybe_clear_kco_sessions()
+	 * Check if Klarna sessions needs to be cleared when purchase is done.
+	 */
+	public function maybe_clear_kco_sessions( $order_id ) {
+		// Clear session and empty cart.
+		if ( method_exists( WC()->session, '__unset' ) ) {
+			if( WC()->session->get( 'klarna_checkout' ) ) {
+				WC()->session->__unset( 'klarna_checkout' );
+			}
+			if( WC()->session->get( 'klarna_checkout_country' ) ) {
+				WC()->session->__unset( 'klarna_checkout_country' );
+			}
+			if( WC()->session->get( 'ongoing_klarna_order' ) ) {
+				WC()->session->__unset( 'ongoing_klarna_order' );
+			}
+			if( WC()->session->get( 'klarna_order_note' ) ) {
+				WC()->session->__unset( 'klarna_order_note' );
+			}
+			if( WC()->session->get( 'klarna_separate_shipping' ) ) {
+				WC()->session->__unset( 'klarna_separate_shipping' );
+			}
+		}
+		
 	}
 
 	function use_ongoing_order_for_kco() {

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -417,10 +417,15 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 **/
 	function process_subscription_payment( $amount_to_charge, $order ) {
 		if ( 0 == $amount_to_charge ) {
-			// Payment complete
-			$order->payment_complete();
+			// Double check the amount by calculating order totals
+			$order->calculate_totals( false );
 
-			return true;
+			if ( 0 == $order->get_total() ) {
+
+				// Payment complete
+				$order->payment_complete();
+				return true;
+			}
 		}
 
 		$order_id = klarna_wc_get_order_id( $order );

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1538,6 +1538,12 @@ class WC_Gateway_Klarna_Checkout_Extra {
 	 *
 	 **/
 	public function change_checkout_url( $url ) {
+
+		// Don't change the url if this is a subscription switch
+		if( isset( $_GET['switch-subscription'] ) || ( method_exists( 'WC_Subscriptions_Switcher', 'cart_contains_switches' ) && WC_Subscriptions_Switcher::cart_contains_switches() ) ) {
+			return $url;
+		}
+
 		if ( ! is_admin() ) {
 			$klarna_checkout_url = WC_Gateway_Klarna_Checkout_Variables::get_klarna_checkout_url();
 			$klarna_country = WC_Gateway_Klarna_Checkout_Variables::get_klarna_country();

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -417,15 +417,9 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 **/
 	function process_subscription_payment( $amount_to_charge, $order ) {
 		if ( 0 == $amount_to_charge ) {
-			// Double check the amount by calculating order totals
-			$order->calculate_totals( false );
-
-			if ( 0 == $order->get_total() ) {
-
-				// Payment complete
-				$order->payment_complete();
-				return true;
-			}
+			// Payment complete
+			$order->payment_complete();
+			return true;
 		}
 
 		$order_id = klarna_wc_get_order_id( $order );

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -81,7 +81,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			'subscription_amount_changes',
 			'subscription_date_changes',
 			'subscription_payment_method_change',
-			// 'subscription_payment_method_change_admin',
+			'subscription_payment_method_change_admin',
 			'multiple_subscriptions'
 		);
 		// Add link to KCO page in standard checkout

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -204,13 +204,17 @@ class WC_Gateway_Klarna_K2WC {
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );
 		}
-
+		
 		if ( WC()->session->get( 'ongoing_klarna_order' ) && wc_get_order( WC()->session->get( 'ongoing_klarna_order' ) ) ) {
 			$orderid = WC()->session->get( 'ongoing_klarna_order' );
 			$order   = wc_get_order( $orderid );
 		} elseif ( WC()->session->get( 'order_awaiting_payment' ) && wc_get_order( WC()->session->get( 'order_awaiting_payment' ) ) ) {
+			// An order exist, probably started with another payment method.
 			$orderid = WC()->session->get( 'order_awaiting_payment' );
 			$order   = wc_get_order( $orderid );
+			// Set ongoing_klarna_order for this order_id.
+			WC()->session->set( 'ongoing_klarna_order', klarna_wc_get_order_id( $order ) );
+			$order->add_order_note( __( 'Changed to Klarna Checkout as payment method.', 'woocommerce-gateway-klarna' ) );
 		} else {
 			// Create order in WooCommerce if we have an email.
 			$order = $this->create_order();

--- a/classes/class-wc-to-klarna.php
+++ b/classes/class-wc-to-klarna.php
@@ -367,20 +367,24 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return string $item_name Cart item name.
 	 */
 	public function get_item_name( $cart_item ) {
-		$cart_item_data = $cart_item['data'];
-		$cart_item_post = klarna_wc_get_cart_item_post( $cart_item_data );
-		$item_name      = $cart_item_post->post_title;
-		$item_data      = klarna_wc_get_cart_item_data( $cart_item );
+		if ( method_exists( $cart_item, 'get_name' ) ) {
+			$item_name = $cart_item['data']->get_name();
+		} else {
+			$cart_item_data = $cart_item['data'];
+			$cart_item_post = klarna_wc_get_cart_item_post( $cart_item_data );
+			$item_name      = $cart_item_post->post_title;
+			$item_data      = klarna_wc_get_cart_item_data( $cart_item );
 
-		// Get variations as a string and remove line breaks
-		$item_variations = html_entity_decode( rtrim( $item_data ) ); // Removes new line at the end.
-		$item_variations = str_replace( "\n", ', ', $item_variations ); // Replaces all other line breaks with commas.
+			// Get variations as a string and remove line breaks
+			$item_variations = html_entity_decode( rtrim( $item_data ) ); // Removes new line at the end.
+			$item_variations = str_replace( "\n", ', ', $item_variations ); // Replaces all other line breaks with commas.
 
-		// Add variations to name.
-		if ( '' !== $item_variations ) {
-			$item_name .= ' [' . $item_variations . ']';
+			// Add variations to name.
+			if ( '' !== $item_variations ) {
+				$item_name .= ' [' . $item_variations . ']';
+			}
 		}
-
+		
 		return apply_filters( 'klarna_item_name', strip_tags( $item_name ), $cart_item );
 	}
 

--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -176,11 +176,4 @@ if ( ! did_action( 'woocommerce_thankyou' ) ) {
 	do_action( 'woocommerce_thankyou', $order_id );
 }
 
-// Clear session and empty cart.
-WC()->session->__unset( 'klarna_checkout' );
-WC()->session->__unset( 'klarna_checkout_country' );
-WC()->session->__unset( 'ongoing_klarna_order' );
-WC()->session->__unset( 'klarna_order_note' );
-WC()->session->__unset( 'klarna_separate_shipping' );
-
 wc_clear_cart_after_payment(); // Clear cart.

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: krokedil, niklashogefjord, slobodanmanic
 Tags: ecommerce, e-commerce, woocommerce, klarna
 Requires at least: 4.2
-Tested up to: 4.9.6
+Tested up to: 4.9.7
 WC requires at least: 3.0.0
-WC tested up to: 3.4.0
+WC tested up to: 3.4.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/vendor/krokedil/krokedil-logger/src/krokedil-order-event-log.php
+++ b/vendor/krokedil/krokedil-logger/src/krokedil-order-event-log.php
@@ -147,7 +147,7 @@ function krokedil_meta_contents() {
 		echo '<h4>' . $event['title'] . '</h4>';
 		echo '<h5 class="krokedil_timestamp" data-event-nr="' . $i . '"><a href="#krokedil_event_nr_' . $i . '">Time: ' . $event['timestamp'] . '</a></h5>';
 		echo '</div>';
-		echo '<div class="krokedil_json krokedil_hidden" id="krokedil_event_nr_' . $i . '">' . json_encode( $event['data'] ) . '</div>';
+		echo '<div class="krokedil_json krokedil_hidden" id="krokedil_event_nr_' . $i . '">' . strip_tags( json_encode( $event['data'] ) ) . '</div>';
 		echo '</div>';
 	}
 	echo '<small>Version of plugin used for order: ' . krokedil_get_order_version() . '</small>';

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -2,16 +2,16 @@
 /**
  * WooCommerce Klarna Gateway
  *
- * @link https://woocommerce.com/products/klarna/
+ * @link https://krokedil.com/klarna-for-woocommerce-v2/
  * @since 0.3
  *
  * @package WC_Gateway_Klarna
  *
  * @wordpress-plugin
  * Plugin Name:     WooCommerce Klarna Gateway
- * Plugin URI:      https://woocommerce.com/products/klarna/
- * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.5.14
+ * Plugin URI:      https://krokedil.com/klarna-for-woocommerce-v2/
+ * Description:     Extends WooCommerce. Provides a <a href="https://www.klarna.com/" target="_blank">Klarna</a> gateway for WooCommerce.
+ * Version:         2.5.15
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -19,7 +19,7 @@
  * Text Domain:     woocommerce-gateway-klarna
  * Domain Path:     /languages
  * WC requires at least: 3.0.
- * WC tested up to: 3.4.0
+ * WC tested up to: 3.4.4
  * Woo: 18624:4edd8b595d6d4b76f31b313ba4e4f3f6
  * Copyright:       © 2009-2018 WooCommerce.
  * License:         GNU General Public License v3.0
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.5.14' );
+	define( 'WC_KLARNA_VER', '2.5.15' );
 }
 
 /**


### PR DESCRIPTION
* Tweak - Move unset kco sessions to maybe_clear_kco_sessions() function.
* Tweak - Added supports subscription_payment_method_change_admin for KCO.
* Tweak - Updated JS event klarna_update_shipping in KCO page so other plugins can update shipping method info and trigger that update to Klarna.
* Fix - Fixes so HTML tags being stripped ocht in KCO logs.
* Fix	- Fixes problem with order started with Swish as payment method but then cancelling and switch to KCO.
* Fix	- Don't change to KCO checkout url if customer is making a subscription switch (then use the regular checkout instead).
* Fix	- Added check for subscription limit for customer in validation callback.
