### PR TITLE
Fixing missing klarna debug flag causing fatal error in weird cases

### DIFF
--- a/includes/checkout/resume.php
+++ b/includes/checkout/resume.php
@@ -101,7 +101,7 @@ try {
 		// Update the order WC id.
 		$kco_country = ( '' !== $kco_session_country ) ? $kco_session_country : $kco_klarna_country;
 		$kco_locale  = ( '' !== $kco_session_locale ) ? $kco_session_locale : $kco_klarna_language;
-		
+
 		if ( $kco_is_rest ) {
 			$kco_currency 	= strtolower( get_woocommerce_currency() );
 			$kco_country 	= strtolower( $kco_country );
@@ -235,7 +235,9 @@ try {
 				$create['options']['allow_separate_shipping_address'] = true;
 			}
 		}
-		krokedil_log_events( $local_order_id, 'Update order', $update );		
+		if ( $klarna_debug == 'yes' ) {
+			krokedil_log_events( $local_order_id, 'Update order', $update );
+		}
 		$klarna_order->update( apply_filters( 'kco_update_order', $update ) );
 	} // End if country change.
 } catch ( Exception $e ) {


### PR DESCRIPTION
The problem is we don't want krokedil log system in our production environment, we ripoff that module. Then we had a weird PHP Fatal error, at the end there was missing a flag for resume.php that was causing it from our modified plugin.

Would be interesting to review the way you use composer and how to handle all those dependencies better instead commit it directly into this plugin.

(Issue related #183)