### PR TITLE
Add Action woocommerce_after_shipping_rate after kco widget shipping …

### DIFF
--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -656,7 +656,7 @@ jQuery(document).ready(function ($) {
 								})
 									.done(function (response) {
 										$('#klarna-checkout-widget').html(response.data.widget_html);
-
+										$(document.body).trigger('kco_shipping_address_change_v2_cb', data, response);
 										window._klarnaCheckout(function (api) {
 											api.resume();
 										});

--- a/classes/class-klarna-shortcodes.php
+++ b/classes/class-klarna-shortcodes.php
@@ -488,6 +488,7 @@ class WC_Gateway_Klarna_Shortcodes {
 												   class="shipping_method"/>
 											<label
 												for="shipping_method_<?php echo esc_attr( $index ); ?>_<?php echo esc_attr( sanitize_title( $method->id ) ); ?>"><?php echo wp_kses_post( wc_cart_totals_shipping_method_label( $method ) ); ?></label>
+											<?php do_action( 'woocommerce_after_shipping_rate', $method, $index ); ?>
 										</li>
 									<?php endforeach; ?>
 								</ul>


### PR DESCRIPTION
Allows for content to be hooked in during kco v2 page just like the other pages.
